### PR TITLE
Fix steamcmd for new base image

### DIFF
--- a/arkmanager/arkmanager.cfg
+++ b/arkmanager/arkmanager.cfg
@@ -6,9 +6,9 @@ install_datadir="/usr/share/arkmanager"
 
 
 # config SteamCMD
-steamcmdroot="/home/steam/.steam/steamcmd"                                 # path of your steamcmd instance
-steamcmdexec="steamcmd.sh"                                             # name of steamcmd executable
-steamcmd_user="steam"                                               # name of the system user who own steamcmd folder
+steamcmdroot="/usr/games"                                            # path of your steamcmd instance - change this to "/usr/games" on Debian/Ubuntu/CentOS if you have the steamcmd package installed
+steamcmdexec="steamcmd"                                              # name of steamcmd executable - change this to "steamcmd" on Debian/Ubuntu/CentOS if you have the steamcmd package installed
+steamcmd_user="steam"                                                # name of the system user who own steamcmd folder
 steamcmd_appinfocache="/home/steam/.steam/appcache/appinfo.vdf"      # cache of the appinfo command
 steamcmd_workshoplog="/home/steam/.steam/logs/workshop_log.txt"      # Steam workshop log
 

--- a/run.sh
+++ b/run.sh
@@ -181,7 +181,7 @@ fi
 
 if [ "$am_arkAutoUpdateOnStart" = "true" ]; then
   echo "Updating mods..."
-  arkmanager update --update-mods
+  arkmanager update --update-mods --no-autostart
 else
   echo -n "Waiting for ARK server to be updated: "
   while (! arkmanager checkupdate); do

--- a/run.sh
+++ b/run.sh
@@ -179,7 +179,10 @@ if [ "$LIST_MOUNTS" = "true" ]; then
   exit 0
 fi
 
-if [ "$am_arkAutoUpdateOnStart" != "true" ]; then
+if [ "$am_arkAutoUpdateOnStart" = "true" ]; then
+  echo "Updating mods..."
+  arkmanager update --update-mods
+else
   echo -n "Waiting for ARK server to be updated: "
   while (! arkmanager checkupdate); do
     echo -n "."


### PR DESCRIPTION
Update mods before the server is started to ensure mods are up to date before other servers start.

`latest-master` includes fix in `arkmanager` that makes servers that should not updateOnStart wait until server and mods are updated.