### PR TITLE
chore: enable verbose steamcmd logging install and update on start

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -233,9 +233,9 @@ fi
 # fix for broken steamcmd app_info_print: execute install/update manually, checking for updates fails.
 # https://github.com/ValveSoftware/steam-for-linux/issues/9683#issuecomment-1826928761
 if [ ! -f "$ARKSERVER/steamapps/appmanifest_376030.acf" ]; then
-  arkmanager install --verbose
+  arkmanager install ${VERBOSE:+--verbose}
 elif [ "$am_arkAutoUpdateOnStart" = "true" ]; then
-  arkmanager update --force --no-autostart --verbose
+  arkmanager update --force --no-autostart ${VERBOSE:+--verbose}
 fi
 
 # run in subshell, so it does not trap signals

--- a/run.sh
+++ b/run.sh
@@ -233,9 +233,9 @@ fi
 # fix for broken steamcmd app_info_print: execute install/update manually, checking for updates fails.
 # https://github.com/ValveSoftware/steam-for-linux/issues/9683#issuecomment-1826928761
 if [ ! -f "$ARKSERVER/steamapps/appmanifest_376030.acf" ]; then
-  arkmanager install
+  arkmanager install --verbose
 elif [ "$am_arkAutoUpdateOnStart" = "true" ]; then
-  arkmanager update --force --no-autostart
+  arkmanager update --force --no-autostart --verbose
 fi
 
 # run in subshell, so it does not trap signals

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPODIR="$(dirname "$SCRIPTDIR")"
 ARKSERVER=${ARKSERVER_SHARED:-"/ark/server"}
+VERBOSE=${VERBOSE:-"--verbose"}
 
 # Always fail script if a command fails
 set -eo pipefail
@@ -233,12 +234,12 @@ fi
 # fix for broken steamcmd app_info_print: execute install/update manually, checking for updates fails.
 # https://github.com/ValveSoftware/steam-for-linux/issues/9683#issuecomment-1826928761
 if [ ! -f "$ARKSERVER/steamapps/appmanifest_376030.acf" ]; then
-  arkmanager install ${VERBOSE:+--verbose}
+  arkmanager install ${VERBOSE}
 elif [ "$am_arkAutoUpdateOnStart" = "true" ]; then
-  arkmanager update --force --no-autostart ${VERBOSE:+--verbose}
+  arkmanager update --force --no-autostart ${VERBOSE}
 fi
 
 # run in subshell, so it does not trap signals
-(arkmanager start --no-background --verbose) &
+(arkmanager start --no-background ${VERBOSE}) &
 arkmanpid=$!
 wait $arkmanpid


### PR DESCRIPTION
Its quite handy to have an idea what steamcmd is doing, in case it fails.
Primarily when downloading/installing/updating ark on startup