### PR TITLE
fix: correctly check for sudo prior to cron start

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -129,7 +129,7 @@ fi
 # If there is uncommented line in the file
 CRONNUMBER=`grep -v "^#" /ark/config/crontab | wc -l`
 if [ $CRONNUMBER -gt 0 ]; then
-if [ "$HAS_PRIVILEGES" = false ]; then
+if [ "$HAS_PRIVILEGES" = "false" ]; then
         echo "Starting cron in background as non-root..."
         cron && tail -f /dev/null
 else


### PR DESCRIPTION
There was a mistake where the quoting was missing on the sudo check for cron start.
Leading to non-sudo trying to start a service, which is ofcoarse impossible