### PR TITLE
Fix missing `rsync` dependency causing fresh installs to fail (Fixes #42)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     lsof \
     libc6-i386 \
 #    libsdl2-2.0.0:i386 \
+    rsync \
     sudo \
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
This PR adds the missing `rsync` package to the Dockerfile.

### **Problem**
Fresh installs of SickHub/arkserver fail because arkmanager requires `rsync` during the initial staging step:

```
Copying to staging directory
/usr/local/bin/arkmanager: line 2250: rsync: command not found
```

Without `rsync`, arkmanager cannot stage files and SteamCMD never runs.  
This results in an infinite loop of:

```
Your ARK server exec could not be found.
sed: can't read /ark/server/steamapps/appmanifest_376030.acf
```

### **Fix**
Adds `rsync` to the list of installed packages in the Dockerfile.

### **Impact**
- Fixes fresh installs on all platforms (Docker, TrueNAS, Podman, etc.)
- No impact on existing installs
- No behavioural changes beyond enabling the intended install flow

### **Related Issue**
Fixes #42